### PR TITLE
updates to external package version numbers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: basilisk
-Version: 1.15.1
+Version: 1.15.1002
 Date: 2023-11-15
 Title: Freezing Python Dependencies Inside Bioconductor Packages
 Authors@R: c(person("Aaron", "Lun", role=c("aut", "cre", "cph"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Description:
     This aims to provide a consistent Python environment that can be used reliably by Bioconductor packages.
     Functions are also provided to enable smooth interoperability of multiple Python environments in a single R session.
 License: GPL-3
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 StagedInstall: false
 VignetteBuilder: knitr
 BugReports: https://github.com/LTLA/basilisk/issues

--- a/R/BasiliskEnvironment.R
+++ b/R/BasiliskEnvironment.R
@@ -1,3 +1,6 @@
+BASILISK_SCIKIT_LEARN_VERSION="1.3.2"
+BASILISK_PANDAS_VERSION="2.1.4"
+
 #' The BasiliskEnvironment class
 #'
 #' The BasiliskEnvironment class provides a simple structure 
@@ -23,7 +26,7 @@
 #' 
 #' @examples
 #' BasiliskEnvironment("my_env1", "AaronPackage", 
-#'     packages=c("scikit-learn=1.1.1", "pandas=1.43.1"))
+#'     packages=c(sprintf("scikit-learn=%s", basilisk:::BASILISK_SCIKIT_LEARN_VERSION), sprintf("pandas=%s", basilisk:::BASILISK_PANDAS_VERSION)))
 #' @docType class
 #' @name BasiliskEnvironment-class
 #' @aliases BasiliskEnvironment-class

--- a/R/basiliskStart.R
+++ b/R/basiliskStart.R
@@ -156,7 +156,7 @@
 #' # when supplying a BasiliskEnvironment to basiliskStart):
 #' tmploc <- file.path(tempdir(), "my_package_A")
 #' if (!file.exists(tmploc)) {
-#'     setupBasiliskEnv(tmploc, c('pandas=1.4.3'))
+#'     setupBasiliskEnv(tmploc, c(sprintf('pandas=%s', basilisk:::BASILISK_PANDAS_VERSION)))
 #' }
 #'
 #' # Pulling out the pandas version, as a demonstration:
@@ -169,7 +169,7 @@
 #' # This happily co-exists with our other environment:
 #' tmploc2 <- file.path(tempdir(), "my_package_B")
 #' if (!file.exists(tmploc2)) {
-#'     setupBasiliskEnv(tmploc2, c('pandas=1.4.2'))
+#'     setupBasiliskEnv(tmploc2, c(sprintf('pandas=%s', basilisk:::BASILISK_PANDAS_VERSION)))
 #' }
 #' 
 #' cl2 <- basiliskStart(tmploc2, testload="pandas")

--- a/R/createLocalBasiliskEnv.R
+++ b/R/createLocalBasiliskEnv.R
@@ -20,7 +20,7 @@
 #'
 #' @examples
 #' tmploc <- file.path(tempdir(), "my_package_C")
-#' tmp <- createLocalBasiliskEnv(tmploc, packages="pandas==1.4.3")
+#' tmp <- createLocalBasiliskEnv(tmploc, packages=sprintf("pandas==%s", basilisk:::BASILISK_PANDAS_VERSION))
 #' basiliskRun(env=tmp, fun=function() { 
 #'     X <- reticulate::import("pandas"); X$`__version__` 
 #' }, testload="pandas")

--- a/R/obtainEnvironmentPath.R
+++ b/R/obtainEnvironmentPath.R
@@ -17,12 +17,13 @@
 #'
 #' tmploc <- file.path(tempdir(), "my_package_A")
 #' if (!file.exists(tmploc)) {
-#'     setupBasiliskEnv(tmploc, c('pandas=1.4.3'))
+#'     setupBasiliskEnv(tmploc, c(sprintf('pandas=%s', basilisk:::BASILISK_PANDAS_VERSION)))
 #' }
 #' obtainEnvironmentPath(tmploc)
 #'
 #' env <- BasiliskEnvironment("test_env", "basilisk", 
-#'     packages=c("scikit-learn=1.1.1", "pandas=1.43.1"))
+#'     packages=c(sprintf("scikit-learn=%s", basilisk:::BASILISK_SCIKIT_LEARN_VERSION), 
+#'                  sprintf("pandas=%s", basilisk:::BASILISK_PANDAS_VERSION)))
 #' \dontrun{obtainEnvironmentPath(env)}
 #' @export
 #' @importFrom dir.expiry lockDirectory unlockDirectory touchDirectory

--- a/R/setupBasiliskEnv.R
+++ b/R/setupBasiliskEnv.R
@@ -61,7 +61,7 @@
 #'
 #' tmploc <- file.path(tempdir(), "my_package_A")
 #' if (!file.exists(tmploc)) {
-#'     setupBasiliskEnv(tmploc, c('pandas=1.4.3'))
+#'     setupBasiliskEnv(tmploc, c(sprintf('pandas=%s', basilisk:::BASILISK_PANDAS_VERSION)))
 #' }
 #'
 #' @seealso

--- a/R/useBasiliskEnv.R
+++ b/R/useBasiliskEnv.R
@@ -24,7 +24,7 @@
 #'
 #' tmploc <- file.path(tempdir(), "my_package_A")
 #' if (!file.exists(tmploc)) {
-#'     setupBasiliskEnv(tmploc, c('pandas==1.4.3'))
+#'     setupBasiliskEnv(tmploc, c(sprintf('pandas==%s',basilisk:::BASILISK_PANDAS_VERSION)))
 #' }
 #'
 #' # This may or may not work, depending on whether a Python instance

--- a/inst/example/R/basilisk.R
+++ b/inst/example/R/basilisk.R
@@ -1,10 +1,22 @@
+# these values should be taken from package-accessible function
+BASILISK_SCIKIT_LEARN_VERSION="1.3.2"
+BASILISK_PANDAS_VERSION="2.1.4"
+BASILISK_PYTHON_DATEUTIL_VERSION="2.8.2"
+BASILISK_PYTHON_DATEUTIL_VERSION_OLD="2.8.1"
+BASILISK_PYTZ_VERSION="2022.2"
+BASILISK_PYTZ_VERSION_OLD="2022.1"
+
 #' @importFrom basilisk BasiliskEnvironment
 env1 <- BasiliskEnvironment("env1", pkgname="son.of.basilisk",
-    packages=c("pandas==1.4.3", "python-dateutil==2.8.2", "pytz==2022.2.1"))
+    packages=c(sprintf("pandas==%s", son.of.basilisk:::BASILISK_PANDAS_VERSION), 
+              sprintf("python-dateutil==%s", son.of.basilisk:::BASILISK_PYTHON_DATEUTIL_VERSION), 
+              sprintf("pytz==%s", son.of.basilisk:::BASILISK_PYTZ_VERSION)))
 
 #' @importFrom basilisk BasiliskEnvironment
 env2 <- BasiliskEnvironment("env2", pkgname="son.of.basilisk",
-    packages=c("scikit-learn==1.1.1", "python-dateutil==2.8.1", "pytz==2022.1"))
+    packages=c(sprintf("scikit-learn==%s", son.of.basilisk:::BASILISK_SCIKIT_LEARN_VERSION), 
+              sprintf("python-dateutil==%s", son.of.basilisk:::BASILISK_PYTHON_DATEUTIL_VERSION_OLD), 
+              sprintf("pytz==%s", son.of.basilisk:::BASILISK_PYTZ_VERSION_OLD)))
 
 #' @importFrom basilisk BasiliskEnvironment
 env3 <- BasiliskEnvironment("env3", pkgname="son.of.basilisk",

--- a/man/BasiliskEnvironment-class.Rd
+++ b/man/BasiliskEnvironment-class.Rd
@@ -29,7 +29,7 @@ These paths are interpreted relative to the system directory of \code{pkgname}, 
 
 \examples{
 BasiliskEnvironment("my_env1", "AaronPackage", 
-    packages=c("scikit-learn=1.1.1", "pandas=1.43.1"))
+    packages=c(sprintf("scikit-learn=\%s", basilisk:::BASILISK_SCIKIT_LEARN_VERSION), sprintf("pandas=\%s", basilisk:::BASILISK_PANDAS_VERSION)))
 }
 \author{
 Aaron lun

--- a/man/basiliskStart.Rd
+++ b/man/basiliskStart.Rd
@@ -196,7 +196,7 @@ This will limit any modifications to the environment variables to a separate R p
 # when supplying a BasiliskEnvironment to basiliskStart):
 tmploc <- file.path(tempdir(), "my_package_A")
 if (!file.exists(tmploc)) {
-    setupBasiliskEnv(tmploc, c('pandas=1.4.3'))
+    setupBasiliskEnv(tmploc, c(sprintf('pandas=\%s', basilisk:::BASILISK_PANDAS_VERSION)))
 }
 
 # Pulling out the pandas version, as a demonstration:
@@ -209,7 +209,7 @@ basiliskStop(cl)
 # This happily co-exists with our other environment:
 tmploc2 <- file.path(tempdir(), "my_package_B")
 if (!file.exists(tmploc2)) {
-    setupBasiliskEnv(tmploc2, c('pandas=1.4.2'))
+    setupBasiliskEnv(tmploc2, c(sprintf('pandas=\%s', basilisk:::BASILISK_PANDAS_VERSION)))
 }
 
 cl2 <- basiliskStart(tmploc2, testload="pandas")

--- a/man/createLocalBasiliskEnv.Rd
+++ b/man/createLocalBasiliskEnv.Rd
@@ -28,7 +28,7 @@ and that concurrent access to the environment is done safely.
 }
 \examples{
 tmploc <- file.path(tempdir(), "my_package_C")
-tmp <- createLocalBasiliskEnv(tmploc, packages="pandas==1.4.3")
+tmp <- createLocalBasiliskEnv(tmploc, packages=sprintf("pandas==\%s", basilisk:::BASILISK_PANDAS_VERSION))
 basiliskRun(env=tmp, fun=function() { 
     X <- reticulate::import("pandas"); X$`__version__` 
 }, testload="pandas")

--- a/man/obtainEnvironmentPath.Rd
+++ b/man/obtainEnvironmentPath.Rd
@@ -24,12 +24,13 @@ Obtain a path to a Conda environment, lazily installing it if necessary.
 
 tmploc <- file.path(tempdir(), "my_package_A")
 if (!file.exists(tmploc)) {
-    setupBasiliskEnv(tmploc, c('pandas=1.4.3'))
+    setupBasiliskEnv(tmploc, c(sprintf('pandas=\%s', basilisk:::BASILISK_PANDAS_VERSION)))
 }
 obtainEnvironmentPath(tmploc)
 
 env <- BasiliskEnvironment("test_env", "basilisk", 
-    packages=c("scikit-learn=1.1.1", "pandas=1.43.1"))
+    packages=c(sprintf("scikit-learn=\%s", basilisk:::BASILISK_SCIKIT_LEARN_VERSION), 
+                 sprintf("pandas=\%s", basilisk:::BASILISK_PANDAS_VERSION)))
 \dontrun{obtainEnvironmentPath(env)}
 }
 \author{

--- a/man/setupBasiliskEnv.Rd
+++ b/man/setupBasiliskEnv.Rd
@@ -79,7 +79,7 @@ Of course, it is possible to specify an entirely different version of Python in 
 
 tmploc <- file.path(tempdir(), "my_package_A")
 if (!file.exists(tmploc)) {
-    setupBasiliskEnv(tmploc, c('pandas=1.4.3'))
+    setupBasiliskEnv(tmploc, c(sprintf('pandas=\%s', basilisk:::BASILISK_PANDAS_VERSION)))
 }
 
 }

--- a/man/useBasiliskEnv.Rd
+++ b/man/useBasiliskEnv.Rd
@@ -31,7 +31,7 @@ This function will modify a suite of environment variables as a side effect
 
 tmploc <- file.path(tempdir(), "my_package_A")
 if (!file.exists(tmploc)) {
-    setupBasiliskEnv(tmploc, c('pandas==1.4.3'))
+    setupBasiliskEnv(tmploc, c(sprintf('pandas==\%s',basilisk:::BASILISK_PANDAS_VERSION)))
 }
 
 # This may or may not work, depending on whether a Python instance

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,10 +1,15 @@
 # Setting up common variables.
 
-test.pandas <- "pandas==1.4.3"
-test.pandas.deps <- c("python-dateutil==2.8.2", "pytz==2022.2.1")
+BASILISK_PANDAS_CURRENT <- "2.1.4"
+BASILISK_PANDAS_OLD <- "2.0.3"
+BASILISK_PYARROW_CURRENT <- "14.0.2"
+BASILISK_PYARROW_OLD <- "14.0.1"
 
-old.pandas <- "pandas==1.4.2"
-old.pandas.deps <- c("python-dateutil==2.8.1", "pytz==2022.1")
+test.pandas <- sprintf("pandas==%s", BASILISK_PANDAS_CURRENT)
+test.pandas.deps <- sprintf("pyarrow==%s", BASILISK_PYARROW_CURRENT)
+old.pandas <- sprintf("pandas==%s", BASILISK_PANDAS_OLD)
+old.pandas.deps <- sprintf("pyarrow==%s", BASILISK_PYARROW_OLD)
+
 
 client.dir <- "install-test-client"
 unlink(client.dir, recursive=TRUE)

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -30,19 +30,20 @@ test_that("setupBasiliskEnv obtains the correct version of the packages", {
     expect_true("pandas" %in% info$package)
 })
 
-test_that("setupBasiliskEnv will install Python 2.7 if requested", {
-    # Python 2.7 binaries aren't provided for Arm64, so we'll just skip it.
-    skip_on_os(c("mac", "linux"), arch="aarch64")
-
-    basilisk.utils::unlink2(target)
-    setupBasiliskEnv(target, "python=2.7")
-    env.py <- basilisk.utils::getPythonBinary(target)
-    py.ver <- system2(env.py, "--version", stderr=TRUE, stdout=TRUE)
-    expect_match(py.ver, "2\\.7")
-
-    # Same if we use the lister.
-    expect_match(listPythonVersion(target), "^2\\.7")
-})
+# MOVE TO LONGTESTS
+# test_that("setupBasiliskEnv will install Python 2.7 if requested", {
+#     # Python 2.7 binaries aren't provided for Arm64, so we'll just skip it.
+#     skip_on_os(c("mac", "linux"), arch="aarch64")
+# 
+#     basilisk.utils::unlink2(target)
+#     setupBasiliskEnv(target, "python=2.7")
+#     env.py <- basilisk.utils::getPythonBinary(target)
+#     py.ver <- system2(env.py, "--version", stderr=TRUE, stdout=TRUE)
+#    expect_match(py.ver, "2\\.7")
+#
+#    # Same if we use the lister.
+#    expect_match(listPythonVersion(target), "^2\\.7")
+#})
 
 test_that("setupBasiliskEnv works with PyPi-hosted packages", {
     basilisk.utils::unlink2(target)
@@ -57,7 +58,7 @@ test_that("setupBasiliskEnv works with local packages", {
     basilisk.utils::unlink2(target)
     setupBasiliskEnv(target, packages=character(0), paths=system.file("example", "inst", "test_dummy", package="basilisk"))
     incoming <- basilisk:::.basilisk_freeze(target)
-    expect_true("test-dummy==0.1" %in% incoming)
+    expect_true("test_dummy==0.1" %in% incoming)
 })
 
 test_that("setupBasiliskEnv destroys directory on error", {

--- a/vignettes/motivation.Rmd
+++ b/vignettes/motivation.Rmd
@@ -54,17 +54,18 @@ We will assume that readers are familiar with general R package development prac
 
 Typically, we need to create some environments with the requisite packages using the `conda` package manager.
 A `basilisk.R` file should be present in the `R/` subdirectory containing commands to produce a `BasiliskEnvironment` object.
-These objects define the Python environments to be constructed by `r Biocpkg("basilisk")` on behalf of your client package.
+These objects define the Python environments to be constructed by `r Biocpkg("basilisk")` on behalf of your client package.  **Note that constraints may arise depending on which
+miniconda version is installed to support the version of basilisk in use.**
 
 ```{r}
 my_env <- BasiliskEnvironment(envname="my_env_name",
     pkgname="ClientPackage",
-    packages=c("pandas==1.4.3", "scikit-learn==1.1.1")
+    packages=c("pandas==2.1.4", "scikit-learn==1.3.2")
 )
 
 second_env <- BasiliskEnvironment(envname="second_env_name",
     pkgname="ClientPackage",
-    packages=c("scipy=1.9.1", "numpy==1.22.1") 
+    packages=c("scipy=1.11.4", "numpy==1.26.3") 
 )
 ```
 
@@ -269,7 +270,7 @@ For example, we can easily instantiate a conda environment in our working direct
 
 ```{r}
 tmp <- createLocalBasiliskEnv("basilisk-vignette-test",
-    packages=c("scikit-learn=1.1.1", "numpy=1.22.1"))
+    packages=c("scikit-learn=1.3.2", "numpy=1.26.3"))
 ```
 
 We can then supply this environment's path to `basiliskRun()` to execute Python-based calculations.
@@ -302,7 +303,7 @@ if (!file.exists(tmp2)) {
         basilisk.utils::getCondaDir(), 
         basilisk.utils::getCondaBinary()
     )
-    conda_install(tmp2, packages=c("scipy==1.9.1"), python_version="3.10", conda=conda.bin)
+    conda_install(tmp2, packages=c("scipy==1.11.4"), python_version="3.11", conda=conda.bin)
 }
 
 basiliskRun(env=tmp2, fun=function(mat) {


### PR DESCRIPTION
This PR represents a first step to reducing the scattering of external package
version numbers by mapping them to package variables like BASILISK_PANDAS_VERSION.
If this is successful, further systematization can be brought in with a function or object
that collects the versions suitable for a given release.  Appropriate choices of external
package versions can be dependent on the miniconda version used.

External package versions for pandas, scipy, numpy etc. were the current release
versions as of 16 Jan 2023.  Some external package specs are deliberately earlier
versions to demonstrate capacity to manage multiple versions of a given package.

One test that assesses ability to depend on python 2.7 was commented out to be moved
to longtests in a future PR.