### PR TITLE
Force basilisk to ignore .condarc and only use specified channels.

### DIFF
--- a/R/setupBasiliskEnv.R
+++ b/R/setupBasiliskEnv.R
@@ -98,8 +98,15 @@ setupBasiliskEnv <- function(envpath, packages, channels="conda-forge", pip=NULL
     dir.create2(envpath)
     on.exit(if (!success) unlink2(envpath), add=TRUE, after=FALSE)
     
-    conda_install(envname=normalizePath(envpath), conda=conda.cmd, 
-        python_version=version, packages=packages, channel=channels)
+    conda_install(
+        envname=normalizePath(envpath), 
+        conda=conda.cmd, 
+        python_version=version, 
+        packages=packages,
+        channel=channels,
+        additional_create_args="--override-channels",
+        additional_install_args="--override-channels"
+    )
 
     pip.cmd <- c("-m", "pip", "install", "--no-user")
 

--- a/vignettes/motivation.Rmd
+++ b/vignettes/motivation.Rmd
@@ -15,7 +15,6 @@ vignette: >
 
 ```{r, echo=FALSE, results="hide"}
 knitr::opts_chunk$set(error=FALSE, warning=FALSE, message=FALSE)
-library(basilisk)
 library(BiocStyle)
 ```
 
@@ -57,6 +56,7 @@ A `basilisk.R` file should be present in the `R/` subdirectory containing comman
 These objects define the Python environments to be constructed by `r Biocpkg("basilisk")` on behalf of your client package.
 
 ```{r}
+library(basilisk)
 my_env <- BasiliskEnvironment(envname="my_env_name",
     pkgname="ClientPackage",
     packages=c("pandas==1.4.3", "scikit-learn==1.1.1")
@@ -311,7 +311,14 @@ if (!file.exists(tmp2)) {
         basilisk.utils::getCondaDir(), 
         basilisk.utils::getCondaBinary()
     )
-    conda_install(tmp2, packages=c("scipy==1.9.1"), python_version="3.10", conda=conda.bin)
+    conda_install(tmp2, 
+        packages=c("scipy==1.9.1"), 
+        python_version="3.10", 
+        channels="conda-forge",
+        additional_create_args="--override-channels",
+        additional_install_args="--override-channels",
+        conda=conda.bin
+    )
 }
 
 basiliskRun(env=tmp2, fun=function(mat) {


### PR DESCRIPTION
This improves the consistency of the environments across different users and systems that might specify more channels in their .condarc.

Maybe should wait for the next release before merging, this is potentially a breaking change for some users (though affects environments were probably already "wrong" if they were pulling from unspecified channels.)

Needs rstudio/reticulate#1594.